### PR TITLE
updating contributing file to get rid of typo error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ git remote add upstream https://github.com/skate1512/Toggle_Keys_Notification.gi
 git remote -v
 ```
 
-**6.** It is always advused to take a pull from the upstream repository to your master branch to keep it even with the main project(updated repository).
+**6.** It is always advised to take a pull from the upstream repository to your master branch to keep it even with the main project(updated repository).
 
 ```
 git pull upstream master(or main)


### PR DESCRIPTION
While going through the 'contributing' file, I observed small tying error. have fixed the same.

original:
**6.** It is always **_advused_** to take a pull from the upstream repository to your master branch to keep it even with the main project(updated repository).

after making changes:
**6.** It is always **_advised_** to take a pull from the upstream repository to your master branch to keep it even with the main project(updated repository).